### PR TITLE
Centroid support

### DIFF
--- a/app/views/sites/show.json.jbuilder
+++ b/app/views/sites/show.json.jbuilder
@@ -7,9 +7,11 @@ json.settlement_hierarchy @site.settlement_hierarchy
 json.green_brown          @site.green_brown
 json.reason               @site.reason
 
-if @site.boundary
+feature_value = @site.boundary || @site.centroid
+
+if feature_value
   feature = RGeo::GeoJSON::EntityFactory.instance.feature(
-    @site.boundary,
+    feature_value,
     nil,
     {
       name:  @site.address,

--- a/db/migrate/20150423074826_add_centroid_to_sites.rb
+++ b/db/migrate/20150423074826_add_centroid_to_sites.rb
@@ -1,0 +1,5 @@
+class AddCentroidToSites < ActiveRecord::Migration
+  def change
+    add_column :sites, :centroid, :st_point, srid: 4326
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150323115532) do
+ActiveRecord::Schema.define(version: 20150423074826) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20150323115532) do
     t.integer  "total_score"
     t.integer  "ranking"
     t.geometry "boundary",             limit: {:srid=>4326, :type=>"polygon"}
+    t.geometry "centroid",             limit: {:srid=>4326, :type=>"point"}
   end
 
   add_index "sites", ["shlaa_ref"], name: "index_sites_on_shlaa_ref", unique: true, using: :btree

--- a/features/support/database_cleaner.rb
+++ b/features/support/database_cleaner.rb
@@ -1,0 +1,3 @@
+DatabaseCleaner.strategy = :deletion, {:except => %w[spatial_ref_sys]}
+DatabaseCleaner.clean_with :truncation, {:except => %w[spatial_ref_sys]}
+Cucumber::Rails::Database.javascript_strategy = :truncation, { :except=>%w[spatial_ref_sys] }

--- a/lib/site_allocations/import/sites.rb
+++ b/lib/site_allocations/import/sites.rb
@@ -15,6 +15,17 @@ module SiteAllocations
             site.green_brown = row['Green/Brown']
             site.reason = row['Reason']
           end
+
+          if row['Easting'] && row['Northing'] && row['Northing'] != 'area' # temporary workaround for 5158
+            point_wkt = "POINT(#{row['Easting']} #{row['Northing']})"
+            Site.connection.execute(
+              <<-SQL
+                UPDATE sites
+                SET centroid = ST_Transform(ST_GeomFromText('#{point_wkt}', 27700), 4326)
+                WHERE shlaa_ref='#{row['SHLAA Ref']}'
+              SQL
+            )
+          end
         end
       end
     end

--- a/lib/tasks/import/from_web.rake
+++ b/lib/tasks/import/from_web.rake
@@ -4,7 +4,7 @@ require 'site_allocations/import/scores'
 require 'open-uri'
 
 namespace :import do
-  desc 'Import all'
+  desc 'Import all from web'
   task :from_web => :environment do
     module SiteAllocations::Import
       WEB_BASE = 'https://raw.githubusercontent.com/rgarner/lcc-site-allocations-data/master/data/output'

--- a/spec/fixtures/import/sites.csv
+++ b/spec/fixtures/import/sites.csv
@@ -1,3 +1,3 @@
-SHLAA Ref,Address,Area ha,_something_,Capacity,I&O RAG,Settlement Hierarchy,Green/Brown,Reason
-34,"Low Hall Road -Riverside Mill, Horsforth LS19",7.9,"",60,LG,Main Urban Area Extension,Brownfield,Site with current or recently expired planning permission or existing UDP allocation. Principle of residential development accepted
-271,"Springfield Road - Springhead Mills, Guiseley",1.9,"",54,LG,Major Settlement Infill,Brownfield,Site with current or recently expired planning permission or existing UDP allocation. Principle of residential development accepted
+SHLAA Ref,Address,Area ha,_something_,Capacity,I&O RAG,Settlement Hierarchy,Green/Brown,Reason,Easting,Northing
+34,"Low Hall Road -Riverside Mill, Horsforth LS19",7.9,"",60,LG,Main Urban Area Extension,Brownfield,Site with current or recently expired planning permission or existing UDP allocation. Principle of residential development accepted,421771,437622
+271,"Springfield Road - Springhead Mills, Guiseley",1.9,"",54,LG,Major Settlement Infill,Brownfield,Site with current or recently expired planning permission or existing UDP allocation. Principle of residential development accepted,419291,442038

--- a/spec/lib/site_allocations/import/sites_spec.rb
+++ b/spec/lib/site_allocations/import/sites_spec.rb
@@ -33,7 +33,7 @@ describe SiteAllocations::Import::Sites do
       example { expect(site.settlement_hierarchy).to eql('Main Urban Area Extension') }
       example { expect(site.green_brown).to eql('Brownfield') }
       example { expect(site.reason).to include('recently expired planning') }
-      example { expect(site.centroid.to_s).to eql('POINT (-1.6706730369853784 53.83440286161263)') }
+      example { expect(site.centroid.to_s).to match /POINT \(-1\.670673.* 53\.8344028.*\)/ }
     end
   end
 end

--- a/spec/lib/site_allocations/import/sites_spec.rb
+++ b/spec/lib/site_allocations/import/sites_spec.rb
@@ -33,6 +33,7 @@ describe SiteAllocations::Import::Sites do
       example { expect(site.settlement_hierarchy).to eql('Main Urban Area Extension') }
       example { expect(site.green_brown).to eql('Brownfield') }
       example { expect(site.reason).to include('recently expired planning') }
+      example { expect(site.centroid.to_s).to eql('POINT (-1.6706730369853784 53.83440286161263)') }
     end
   end
 end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,6 @@
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :deletion, {:except => %w[spatial_ref_sys]}
+    DatabaseCleaner.clean_with :truncation, {:except => %w[spatial_ref_sys]}
+  end
+end

--- a/spec/views/sites/show.json.jbuilder_spec.rb
+++ b/spec/views/sites/show.json.jbuilder_spec.rb
@@ -1,15 +1,6 @@
 require 'rails_helper'
 
 describe 'sites/show.json.jbuilder' do
-  let!(:site) do
-    create(:site,
-           shlaa_ref: '2062',
-           address: 'somewhere',
-           boundary: 'POLYGON((-1.47486759802822 53.8426310787134,-1.47405228707635 53.8434637700614,-1.47035086877967 53.8433086917616,-1.47021270788897 53.8433910009922,-1.46758423736764 53.8432845766634,-1.4696329352046 53.8407270784017,-1.47323823376588 53.840839869631,-1.47336705217763 53.8412007147184,-1.47395562835178 53.8421119831296,-1.47399856782236 53.8424949717742,-1.47440631312983 53.8425993840685,-1.47486759802822 53.8426310787134))',
-           total_score: -12
-    )
-  end
-
   before do
     assign(:site, site)
     render
@@ -17,31 +8,74 @@ describe 'sites/show.json.jbuilder' do
 
   subject(:json) { JSON.parse(rendered) }
 
-  it 'does not include surrogate ID' do
-    expect(json['id']).to be_nil
-  end
-
-  it 'includes the address' do
-    expect(json['address']).to eql('somewhere')
-  end
-
-  describe 'the feature' do
-    subject(:feature) { json['feature'] }
-
-    example { expect(feature['type']).to eql('Feature') }
-
-    describe 'the properties' do
-      subject(:properties) { feature['properties'] }
-
-      example { expect(properties['name']).to  eql(site.address) }
-      example { expect(properties['score']).to eql(site.total_score) }
+  context 'site has a boundary and a centroid' do
+    let!(:site) do
+      create(:site,
+             shlaa_ref: '2062',
+             address: 'somewhere',
+             boundary: 'POLYGON((-1.47486759802822 53.8426310787134,-1.47405228707635 53.8434637700614,-1.47035086877967 53.8433086917616,-1.47021270788897 53.8433910009922,-1.46758423736764 53.8432845766634,-1.4696329352046 53.8407270784017,-1.47323823376588 53.840839869631,-1.47336705217763 53.8412007147184,-1.47395562835178 53.8421119831296,-1.47399856782236 53.8424949717742,-1.47440631312983 53.8425993840685,-1.47486759802822 53.8426310787134))',
+             centroid: 'POINT(-1.47486759802822 53.8426310787134)',
+             total_score: -12
+      )
     end
 
-    describe 'the geometry' do
-      subject(:geometry) { feature['geometry'] }
+    it 'does not include surrogate ID' do
+      expect(json['id']).to be_nil
+    end
 
-      example { expect(geometry['type']).to eql('Polygon') }
-      example { expect(geometry['coordinates'][0].size).to eql(12) }
+    it 'includes the address' do
+      expect(json['address']).to eql('somewhere')
+    end
+
+    describe 'the feature is the boundary' do
+      subject(:feature) { json['feature'] }
+
+      example { expect(feature['type']).to eql('Feature') }
+
+      describe 'the properties' do
+        subject(:properties) { feature['properties'] }
+
+        example { expect(properties['name']).to  eql(site.address) }
+        example { expect(properties['score']).to eql(site.total_score) }
+      end
+
+      describe 'the geometry' do
+        subject(:geometry) { feature['geometry'] }
+
+        example { expect(geometry['type']).to eql('Polygon') }
+        example { expect(geometry['coordinates'][0].size).to eql(12) }
+      end
+    end
+  end
+
+  context 'site only has a centroid' do
+    let!(:site) do
+      create(:site,
+             shlaa_ref: '2062',
+             address: 'somewhere',
+             centroid: 'POINT(-1.47486759802822 53.8426310787134)',
+             total_score: -12
+      )
+    end
+
+    describe 'the feature is the centroid' do
+      subject(:feature) { json['feature'] }
+
+      example { expect(feature['type']).to eql('Feature') }
+
+      describe 'the properties' do
+        subject(:properties) { feature['properties'] }
+
+        example { expect(properties['name']).to  eql(site.address) }
+        example { expect(properties['score']).to eql(site.total_score) }
+      end
+
+      describe 'the geometry' do
+        subject(:geometry) { feature['geometry'] }
+
+        example { expect(geometry['type']).to eql('Point') }
+        example { expect(geometry['coordinates']).to eql([-1.47486759802822, 53.8426310787134]) }
+      end
     end
   end
 end


### PR DESCRIPTION
- Add an import mechanism for centroids, which happen as part of `import:sites`
- Add the ability to display via `sites/show.json.jbuilder`
- We really do need tests to stop blowing away `spatial_ref_sys` now
- Also rename an inconsistently-named file with a rake task in it
