### PR TITLE
Add Bing layer support

### DIFF
--- a/app/assets/javascripts/bing_layer.js
+++ b/app/assets/javascripts/bing_layer.js
@@ -1,0 +1,150 @@
+/*
+ See https://github.com/shramov/leaflet-plugins
+
+ Copyright (c) 2011-2014, Pavel Shramov, Bruno Bergot
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without modification, are
+ permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this list of
+ conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice, this list
+ of conditions and the following disclaimer in the documentation and/or other materials
+ provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+L.BingLayer = L.TileLayer.extend({
+    options: {
+        subdomains: [0, 1, 2, 3],
+        type: 'Aerial',
+        attribution: 'Bing',
+        culture: ''
+    },
+
+    initialize: function(key, options) {
+        L.Util.setOptions(this, options);
+
+        this._key = key;
+        this._url = null;
+        this.meta = {};
+        this.loadMetadata();
+    },
+
+    tile2quad: function(x, y, z) {
+        var quad = '';
+        for (var i = z; i > 0; i--) {
+            var digit = 0;
+            var mask = 1 << (i - 1);
+            if ((x & mask) !== 0) digit += 1;
+            if ((y & mask) !== 0) digit += 2;
+            quad = quad + digit;
+        }
+        return quad;
+    },
+
+    getTileUrl: function(p, z) {
+        var zoom = this._getZoomForUrl();
+        var subdomains = this.options.subdomains,
+            s = this.options.subdomains[Math.abs((p.x + p.y) % subdomains.length)];
+        return this._url.replace('{subdomain}', s)
+            .replace('{quadkey}', this.tile2quad(p.x, p.y, zoom))
+            .replace('{culture}', this.options.culture);
+    },
+
+    loadMetadata: function() {
+        var _this = this;
+        var cbid = '_bing_metadata_' + L.Util.stamp(this);
+        window[cbid] = function (meta) {
+            _this.meta = meta;
+            window[cbid] = undefined;
+            var e = document.getElementById(cbid);
+            e.parentNode.removeChild(e);
+            if (meta.errorDetails) {
+                return;
+            }
+            _this.initMetadata();
+        };
+        var url = document.location.protocol + '//dev.virtualearth.net/REST/v1/Imagery/Metadata/' + this.options.type + '?include=ImageryProviders&jsonp=' + cbid +
+            '&key=' + this._key + '&UriScheme=' + document.location.protocol.slice(0, -1);
+        var script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.src = url;
+        script.id = cbid;
+        document.getElementsByTagName('head')[0].appendChild(script);
+    },
+
+    initMetadata: function() {
+        var r = this.meta.resourceSets[0].resources[0];
+        this.options.subdomains = r.imageUrlSubdomains;
+        this._url = r.imageUrl;
+        this._providers = [];
+        if (r.imageryProviders) {
+            for (var i = 0; i < r.imageryProviders.length; i++) {
+                var p = r.imageryProviders[i];
+                for (var j = 0; j < p.coverageAreas.length; j++) {
+                    var c = p.coverageAreas[j];
+                    var coverage = {zoomMin: c.zoomMin, zoomMax: c.zoomMax, active: false};
+                    var bounds = new L.LatLngBounds(
+                        new L.LatLng(c.bbox[0]+0.01, c.bbox[1]+0.01),
+                        new L.LatLng(c.bbox[2]-0.01, c.bbox[3]-0.01)
+                    );
+                    coverage.bounds = bounds;
+                    coverage.attrib = p.attribution;
+                    this._providers.push(coverage);
+                }
+            }
+        }
+        this._update();
+    },
+
+    _update: function() {
+        if (this._url === null || !this._map) return;
+        this._update_attribution();
+        L.TileLayer.prototype._update.apply(this, []);
+    },
+
+    _update_attribution: function() {
+        var bounds = this._map.getBounds();
+        var zoom = this._map.getZoom();
+        for (var i = 0; i < this._providers.length; i++) {
+            var p = this._providers[i];
+            if ((zoom <= p.zoomMax && zoom >= p.zoomMin) &&
+                bounds.intersects(p.bounds)) {
+                if (!p.active && this._map.attributionControl)
+                    this._map.attributionControl.addAttribution(p.attrib);
+                p.active = true;
+            } else {
+                if (p.active && this._map.attributionControl)
+                    this._map.attributionControl.removeAttribution(p.attrib);
+                p.active = false;
+            }
+        }
+    },
+
+    onRemove: function(map) {
+        for (var i = 0; i < this._providers.length; i++) {
+            var p = this._providers[i];
+            if (p.active && this._map.attributionControl) {
+                this._map.attributionControl.removeAttribution(p.attrib);
+                p.active = false;
+            }
+        }
+        L.TileLayer.prototype.onRemove.apply(this, [map]);
+    }
+});
+
+L.bingLayer = function (key, options) {
+    return new L.BingLayer(key, options);
+};

--- a/app/assets/javascripts/feature_map.coffee.erb
+++ b/app/assets/javascripts/feature_map.coffee.erb
@@ -96,9 +96,11 @@ class @FeatureMap
       scrollWheelZoom: false
     })
 
-    L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+    osmLayer = L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
       attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-    }).addTo(@map);
+    }).addTo(@map)
+    bingLayer = L.bingLayer(
+      atob('QWxQRWo2a2oxT3NqeGswRTNVNmREVVMySHBMamtnQS1TRExYWGllTEpJXzdKd1VuNUNDY1F3TWRFaENUUFdycg=='))
 
     @markers = new L.MarkerClusterGroup({
       disableClusteringAtZoom: 13,
@@ -107,6 +109,17 @@ class @FeatureMap
       maxClusterRadius:        60,
       iconCreateFunction:      createClusterIcon
     })
+
+    baseLayers = {
+      "OpenStreetMap": osmLayer,
+      "Bing Aerial": bingLayer
+    }
+
+    overlays = {
+      "Show sites": @markers
+    }
+
+    L.control.layers(baseLayers, overlays).addTo(@map)
 
     @layersByShlaaRef = {}
     @featureLayer = L.geoJson(
@@ -121,7 +134,7 @@ class @FeatureMap
     @markers.addLayer(@featureLayer)
     @markers.addTo(@map);
 
-    @map.addControl(new FitBoundsControl({
+    @map.addControl(new L.FitBoundsControl({
       onClick: @fitBounds
     }))
 

--- a/app/assets/javascripts/fit_bounds.coffee
+++ b/app/assets/javascripts/fit_bounds.coffee
@@ -1,4 +1,4 @@
-@FitBoundsControl = L.Control.extend({
+L.FitBoundsControl = L.Control.extend({
   options: {
     position: 'topleft'
   },

--- a/app/assets/stylesheets/scores.scss
+++ b/app/assets/stylesheets/scores.scss
@@ -14,7 +14,7 @@
 
 path.boundary {
   stroke-width: 2px;
-  fill-opacity: 0.7;
+  fill-opacity: 0.5;
   &.very-positive { fill: $very-positive; stroke: darken($very-positive, 50%); }
   &.positive      { fill: $positive;      stroke: darken($very-positive, 50%); }
   &.neutral       { fill: $neutral;       stroke: darken($neutral, 50%); }


### PR DESCRIPTION
- Use the default Leaflet layers control
- Add option to show sites or not (helps on aerial maps with rapeseed
  fields, for example)
- Reduce site opacity to 0.5 from 0.7 for borders (helps to see detail
  underneath boundaries)
- Since we're using a third-party Bing Layer JS file, be consistent
  with that file's control creation scheme - add our own
  FitBoundsControl under "L." instead of in the global namespace
